### PR TITLE
Add version 1.3

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,11 +3,21 @@
 ---
 fixtures:
   forge_modules:
-    archive: 'puppet/archive'
-    concat: 'puppetlabs/concat'
-    promtail: 'grafana/promtail'
-    systemd: 'camptocamp/systemd'
-    stdlib: 'puppetlabs/stdlib'
+    archive:
+      repo: 'puppet/archive'
+      ref:  '4.2.0'
+    concat:
+      repo: 'puppetlabs/concat'
+      ref:  '6.0.0'
+    promtail:
+      repo: 'grafana/promtail'
+      ref:  '1.0.0'
+    systemd:
+      repo: 'camptocamp/systemd'
+      ref:  '2.0.0'
+    stdlib:
+      repo: 'puppetlabs/stdlib'
+      ref:  '4.25.0'
   repositories:
     facts: 'https://github.com/puppetlabs/puppetlabs-facts.git'
     puppet_agent: 'https://github.com/puppetlabs/puppetlabs-puppet_agent.git'

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -14,4 +14,15 @@ tempo::service_provider: 'systemd'
 tempo::service_ensure: 'running'
 tempo::user: 'tempo'
 tempo::version: '1.1.0'
+tempo::server_config_hash:
+  server:
+    http_listen_port: 3200
+tempo::storage_config_hash:
+  storage:
+    trace:
+      backend: local
+      local:
+        path: '/var/lib/tempo'
+      wal:
+        path: '/var/lib/tempo/wal'
 ...

--- a/data/common.yaml
+++ b/data/common.yaml
@@ -13,7 +13,7 @@ tempo::service_name: 'tempo'
 tempo::service_provider: 'systemd'
 tempo::service_ensure: 'running'
 tempo::user: 'tempo'
-tempo::version: '1.1.0'
+tempo::version: '1.3.2'
 tempo::server_config_hash:
   server:
     http_listen_port: 3200

--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,8 @@
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
         "9",
-        "10"
+        "10",
+        "11"
       ]
     },
     {

--- a/metadata.json
+++ b/metadata.json
@@ -33,8 +33,7 @@
     {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
-        "7",
-        "8"
+        "7"
       ]
     },
     {

--- a/provision.yaml
+++ b/provision.yaml
@@ -4,4 +4,4 @@ puppet5:
   images: ['litmusimage/centos:7','litmusimage/debian:9','litmusimage/debian:10','litmusimage/ubuntu:18.04']
 puppet6:
   provisioner: docker
-  images: ['litmusimage/centos:7','litmusimage/debian:9','litmusimage/debian:10','litmusimage/ubuntu:18.04','litmusimage/ubuntu:20.04']
+  images: ['litmusimage/centos:7','litmusimage/debian:9','litmusimage/debian:10','litmusimage/debian:11','litmusimage/ubuntu:18.04','litmusimage/ubuntu:20.04']

--- a/provision.yaml
+++ b/provision.yaml
@@ -1,7 +1,7 @@
 ---
 puppet5:
   provisioner: docker
-  images: ['litmusimage/centos:7','litmusimage/centos:8','litmusimage/debian:9','litmusimage/debian:10','litmusimage/ubuntu:18.04']
+  images: ['litmusimage/centos:7','litmusimage/debian:9','litmusimage/debian:10','litmusimage/ubuntu:18.04']
 puppet6:
   provisioner: docker
-  images: ['litmusimage/centos:7','litmusimage/centos:8','litmusimage/debian:9','litmusimage/debian:10','litmusimage/ubuntu:18.04','litmusimage/ubuntu:20.04']
+  images: ['litmusimage/centos:7','litmusimage/debian:9','litmusimage/debian:10','litmusimage/ubuntu:18.04','litmusimage/ubuntu:20.04']

--- a/spec/acceptance/class_spec.rb
+++ b/spec/acceptance/class_spec.rb
@@ -32,7 +32,7 @@ PUPPETCODE
     it { is_expected.to be_running.under('systemd') }
   end
 
-  describe port(3100) do
+  describe port(3200) do
     it { is_expected.to be_listening }
   end
 end

--- a/spec/classes/install_spec.rb
+++ b/spec/classes/install_spec.rb
@@ -26,7 +26,7 @@ describe 'tempo' do
         end
 
         it { is_expected.to contain_file('/opt/tempo/tempo').with_group('myspecialgroup') }
-        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.1.0/tempo_1.1.0_linux_amd64.tar.gz').with_group('myspecialgroup') }
+        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.3.2/tempo_1.3.2_linux_amd64.tar.gz').with_group('myspecialgroup') }
       end
 
       context 'with group set to myspecialgroup and install_method set to archive and manage_user set to true' do
@@ -40,7 +40,7 @@ describe 'tempo' do
         end
 
         it { is_expected.to contain_file('/opt/tempo/tempo').with_group('myspecialgroup').that_requires('Group[myspecialgroup]') }
-        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.1.0/tempo_1.1.0_linux_amd64.tar.gz').with_group('myspecialgroup') }
+        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.3.2/tempo_1.3.2_linux_amd64.tar.gz').with_group('myspecialgroup') }
       end
 
       context 'with group set to myspecialgroup and install_method set to archive and manage_user set to false' do
@@ -54,7 +54,7 @@ describe 'tempo' do
         end
 
         it { is_expected.to contain_file('/opt/tempo/tempo').with_group('myspecialgroup').that_requires(nil) }
-        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.1.0/tempo_1.1.0_linux_amd64.tar.gz').with_group('myspecialgroup') }
+        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.3.2/tempo_1.3.2_linux_amd64.tar.gz').with_group('myspecialgroup') }
       end
 
       context 'with bin_dir set to /opt/special' do
@@ -66,8 +66,8 @@ describe 'tempo' do
         end
 
         it { is_expected.to contain_file('/opt/special/tempo') }
-        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.1.0/tempo_1.1.0_linux_amd64.tar.gz').with_creates('/var/lib/tempo/tempo-1.1.0/tempo') }
-        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.1.0/tempo_1.1.0_linux_amd64.tar.gz').with_extract_path('/var/lib/tempo/tempo-1.1.0') }
+        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.3.2/tempo_1.3.2_linux_amd64.tar.gz').with_creates('/var/lib/tempo/tempo-1.3.2/tempo') }
+        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.3.2/tempo_1.3.2_linux_amd64.tar.gz').with_extract_path('/var/lib/tempo/tempo-1.3.2') }
       end
 
       context 'with data_dir set to /opt/special and manage_user set to true' do
@@ -93,7 +93,7 @@ describe 'tempo' do
           }
         end
 
-        it { is_expected.to contain_archive('/opt/tempo/tempo-1.1.0/tempo_1.1.0_linux_amd64.tar.gz') }
+        it { is_expected.to contain_archive('/opt/tempo/tempo-1.3.2/tempo_1.3.2_linux_amd64.tar.gz') }
         it { is_expected.not_to contain_package('tempo') }
       end
 
@@ -107,7 +107,7 @@ describe 'tempo' do
         end
 
         it { is_expected.not_to contain_file('/opt/tempo/tempo').that_comes_before('Archive[tempo archive]') }
-        it { is_expected.not_to contain_archive('/var/lib/tempo/tempo-1.1.0/tempo_1.1.0_linux_amd64.tar.gz') }
+        it { is_expected.not_to contain_archive('/var/lib/tempo/tempo-1.3.2/tempo_1.3.2_linux_amd64.tar.gz') }
         it { is_expected.to contain_package('tempo') }
       end
 
@@ -193,7 +193,7 @@ describe 'tempo' do
         end
 
         it { is_expected.to contain_file('/opt/tempo/tempo').with_owner('myspecialuser') }
-        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.1.0/tempo_1.1.0_linux_amd64.tar.gz').with_user('myspecialuser') }
+        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.3.2/tempo_1.3.2_linux_amd64.tar.gz').with_user('myspecialuser') }
       end
 
       context 'with user set to myspecialuser and install_method set to archive and manage_user set to true' do
@@ -207,7 +207,7 @@ describe 'tempo' do
         end
 
         it { is_expected.to contain_file('/opt/tempo/tempo').with_owner('myspecialuser').that_requires('User[myspecialuser]') }
-        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.1.0/tempo_1.1.0_linux_amd64.tar.gz').with_user('myspecialuser') }
+        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.3.2/tempo_1.3.2_linux_amd64.tar.gz').with_user('myspecialuser') }
       end
 
       context 'with user set to myspecialuser and install_method set to archive and manage_user set to false' do
@@ -221,7 +221,7 @@ describe 'tempo' do
         end
 
         it { is_expected.to contain_file('/opt/tempo/tempo').with_owner('myspecialuser').that_requires(nil) }
-        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.1.0/tempo_1.1.0_linux_amd64.tar.gz').with_user('myspecialuser') }
+        it { is_expected.to contain_archive('/var/lib/tempo/tempo-1.3.2/tempo_1.3.2_linux_amd64.tar.gz').with_user('myspecialuser') }
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -44,6 +44,7 @@ RSpec.configure do |c|
     Puppet.settings[:strict] = :warning
     Puppet.settings[:strict_variables] = true
   end
+  c.facter_implementation = :rspec
   c.filter_run_excluding(bolt: true) unless ENV['GEM_BOLT']
   c.after(:suite) do
   end


### PR DESCRIPTION
Hi,

I was testing your module for Tempo 1.3 and noticed the acceptance tests weren't working. I've done some minor housekeeping if you want it, namely;

- Added minimal default server/storage configuration to get the service to run.
- Dropped support for CentOS 8 (reached its end-of-life 31/12/2021) and added Debian 11
- Set the minimum supported version of forge modules in fixtures
- Set `facter_implementation` as spec tests were taking a long time to run locally
- Changed the expected port to be listening to `3200` - this was changed in [v1.1.0](https://github.com/grafana/tempo/blob/v1.1.0/CHANGELOG.md#v110-rc0--2021-08-11) to prevent the port colliding with Loki examples.

Feel free to cherry-pick what you do/don't want.